### PR TITLE
Catch error when ONION variable isn't present in PATH

### DIFF
--- a/server.py
+++ b/server.py
@@ -44,9 +44,13 @@ p = Path("/home/spotbit/.spotbit/sb.db")
 db = sqlite3.connect(p)
 print(f"db opened in {p}")
 log.debug(f"db opened in {p}")
-ONION = os.environ["ONION"] #get this value from the path
-print(f"spotbit is running at {ONION}")
-
+ONION = ""
+try:
+    ONION = os.environ["ONION"] #get this value from the path
+    print(f"spotbit is running at {ONION}")
+except Exception as e:
+    print(f"cant find ONION in PATH {e}")
+    
 # Database configuration
 # We need to have the database opened manually once so that systemd can access it
 def configure_db():


### PR DESCRIPTION
Added a try/catch at the top of the code here because there is a chance that ONION doesn't get added to the users PATH properly, which would result in the entire program refusing to run. This feature does not effect other aspects of spotbit (its more cosmetic, for the landing page at '/')