### PR TITLE
Remove ftx exchange from spotbit.config

### DIFF
--- a/spotbit.config
+++ b/spotbit.config
@@ -4,7 +4,7 @@
 # debug = True
 
 # exchanges: Exchanges to use for data collection. If this is not set, then Spotbit will use all supported exchanges. There are more than 100 exchanges supported.
-exchanges       = ["liquid", "gemini", "phemex", "bitstamp", "ftx", "binance"]
+exchanges       = ["liquid", "gemini", "phemex", "bitstamp", "binance"]
 
 # currencies: Currencies to collect data for in the Spotbit database. If a currency is supported by an exchange, then data can be collected for it. Currencies should be lowercase three letter currency codes, eg usd gpy cny jpy eur. If no currencies are listed then Spotbit will collect for usd only. 
 currencies      = ["usd", "gbp", "jpy", "usdt", "eur"]


### PR DESCRIPTION
I think it's safe to say FTX should be removed now? :grin: 

I also saw it was in [beancounter.py](https://github.com/BlockchainCommons/spotbit/blob/master/beancounter.py#L85) but wasn't 100% sure what to replace that one with.